### PR TITLE
feat: add monorepo pub workspace support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.4.0 - Monorepo & Workspace Support
+
+- **Monorepo support**: Automatically discovers and manages multiple Flutter projects in a workspace
+- **Hierarchical tree view**: Projects now organized in collapsible groups with per-project outdated counts
+- **Multi-pubspec discovery**: Recursively finds all `pubspec.yaml` files across the workspace
+- **Per-project updates**: Each package update targets the correct project's pubspec file
+- **Respects VS Code settings**: Uses existing `files.exclude` and `search.exclude` patterns for discovery
+- **Smart sorting**: Projects with outdated packages shown first, packages within projects sorted by outdated status
+- **Enhanced UI**: Project folders show icon colors and badges based on their packages' update status
+
 ## 1.3.0 - Version Type Indicators
 
 - Visual indicators for update types: major (red), minor (yellow), and patch (blue) updates

--- a/README.md
+++ b/README.md
@@ -19,17 +19,29 @@ If you like this package, consider checking [UserOrient](https://userorient.com)
 - **Outdated detection** - Warning icons and badge count for outdated packages  
 - **Changelogs** - Click any package to see what changed between versions
 - **One-click updates** - Update to any version directly from changelog
-- **Automatic sorting** - Outdated packages shown first
+- **Automatic sorting** - Projects with outdated packages shown first, outdated packages within each project shown first
 - **Update type indicators** - Color-coded icons for major (🔴), minor (🟡), and patch (🔵) updates
+- **Monorepo support** - Automatically discovers and manages multiple Flutter projects in a workspace
+- **Hierarchical view** - Projects organized with collapsible groups showing outdated counts
 
 ## Usage
 
-1. Open any Flutter project with `pubspec.yaml`
+1. Open any Flutter project or monorepo workspace containing `pubspec.yaml` files
 2. Click the **Pubgrade** icon in Activity Bar (left sidebar)
-3. View all dependencies with version info
-4. **Outdated packages** (⚠️) shown at top
+3. View all projects and their dependencies organized hierarchically
+4. **Outdated packages** (⚠️) shown at top of each project group
 5. **Click a package** to view changelog
-6. **Click "Update to X.X.X"** button to update
+6. **Click "Update to X.X.X"** button to update that specific project's pubspec
+
+## Monorepo/Workspace Support
+
+Pubgrade now fully supports Flutter workspaces and monorepos with multiple projects:
+
+- **Auto-discovery**: Recursively finds all `pubspec.yaml` files in your workspace
+- **Project grouping**: Packages are organized by project with expand/collapse functionality
+- **Per-project updates**: Each package update targets the correct `pubspec.yaml`
+- **Outdated badges**: Shows count of outdated packages per project and globally
+- **Respects VS Code settings**: Uses your existing `files.exclude` and `search.exclude` patterns
 
 ## License
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,25 +31,22 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('pubgrade.updatePackage', async (item) => {
+    vscode.commands.registerCommand('pubgrade.updatePackage', async (item: any) => {
       if (item && item.packageInfo) {
-        const pubspecPath = await findPubspecPath();
-        if (pubspecPath) {
-          const success = await Updater.updatePackage(
-            pubspecPath,
-            item.packageInfo.name,
-            item.packageInfo.latestVersion
-          );
-          if (success) {
-            setTimeout(() => refreshPackages(), 1000);
-          }
+        const success = await Updater.updatePackage(
+          item.packageInfo.pubspecPath,
+          item.packageInfo.name,
+          item.packageInfo.latestVersion
+        );
+        if (success) {
+          setTimeout(() => refreshPackages(), 1000);
         }
       }
     })
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('pubgrade.showChangelog', async (item) => {
+    vscode.commands.registerCommand('pubgrade.showChangelog', async (item: any) => {
       if (item && item.packageInfo) {
         await showChangelogAsDocument(item.packageInfo);
       }
@@ -58,7 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Add click handler for tree items
   context.subscriptions.push(
-    vscode.commands.registerCommand('pubgrade.itemClick', async (item) => {
+    vscode.commands.registerCommand('pubgrade.itemClick', async (item: any) => {
       if (!item.packageInfo.isOutdated) {
         vscode.window.showInformationMessage(`${item.packageInfo.name} is up to date (${item.packageInfo.currentVersion})`);
         return;
@@ -73,18 +70,47 @@ export function activate(context: vscode.ExtensionContext) {
   refreshPackages();
 }
 
-async function findPubspecPath(): Promise<string | null> {
+interface PubspecInfo {
+  path: string;
+  projectName: string;
+}
+
+async function discoverAllPubspecs(): Promise<PubspecInfo[]> {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (!workspaceFolders) {
     vscode.window.showErrorMessage('No workspace folder open');
-    return null;
+    return [];
   }
 
-  const pubspecPath = path.join(workspaceFolders[0].uri.fsPath, 'pubspec.yaml');
-  return pubspecPath;
+  // Find all pubspec.yaml files (VS Code automatically excludes files.exclude and search.exclude patterns)
+  // Explicitly exclude .fvm directory used by Flutter Version Management
+  const pubspecFiles = await vscode.workspace.findFiles(
+    '**/pubspec.yaml',
+    '**/.fvm/**'
+  );
+
+  // Map to PubspecInfo with project names
+  const pubspecs: PubspecInfo[] = pubspecFiles.map((uri: vscode.Uri) => {
+    const fsPath = uri.fsPath;
+    const dirName = path.dirname(fsPath);
+    const projectName = path.basename(dirName);
+    
+    return {
+      path: fsPath,
+      projectName: projectName
+    };
+  });
+
+  return pubspecs;
 }
 
-async function processPackageBatch(dependencies: any[], startIndex: number, batchSize: number): Promise<PackageInfo[]> {
+async function processPackageBatch(
+  dependencies: any[], 
+  startIndex: number, 
+  batchSize: number, 
+  pubspecPath: string, 
+  projectName: string
+): Promise<PackageInfo[]> {
   const batch = dependencies.slice(startIndex, startIndex + batchSize);
   const promises = batch.map(async (dep) => {
     const cleanVersion = PubspecParser.cleanVersion(dep.version);
@@ -99,7 +125,9 @@ async function processPackageBatch(dependencies: any[], startIndex: number, batc
         currentVersion: cleanVersion,
         latestVersion: latestVersion,
         isOutdated: isOutdated,
-        updateType: updateType
+        updateType: updateType,
+        pubspecPath: pubspecPath,
+        projectName: projectName
       };
     }
     return null;
@@ -110,8 +138,11 @@ async function processPackageBatch(dependencies: any[], startIndex: number, batc
 }
 
 async function refreshPackages() {
-  const pubspecPath = await findPubspecPath();
-  if (!pubspecPath) return;
+  const pubspecs = await discoverAllPubspecs();
+  if (pubspecs.length === 0) {
+    vscode.window.showWarningMessage('No pubspec.yaml files found in workspace');
+    return;
+  }
 
   try {
     // Clear badge while loading
@@ -123,33 +154,53 @@ async function refreshPackages() {
         title: 'Pubgrade:',
         cancellable: false
       },
-      async (progress) => {
-        const dependencies = PubspecParser.parse(pubspecPath);
-        const packages: PackageInfo[] = [];
-        const batchSize = 4;
-        const totalBatches = Math.ceil(dependencies.length / batchSize);
+      async (progress: vscode.Progress<{ message?: string; increment?: number }>) => {
+        const allPackages: PackageInfo[] = [];
+        let totalDependencies = 0;
+        let processedDependencies = 0;
 
-        for (let batchIndex = 0; batchIndex < totalBatches; batchIndex++) {
-          const startIndex = batchIndex * batchSize;
-          const endIndex = Math.min(startIndex + batchSize, dependencies.length);
-          const actualBatchSize = endIndex - startIndex;
-          
-          progress.report({
-            message: `${endIndex} of ${dependencies.length} packages checked`,
-            increment: (actualBatchSize / dependencies.length) * 100
-          });
+        // First, count total dependencies across all pubspecs
+        const pubspecDependencies = pubspecs.map(pubspec => ({
+          pubspec,
+          dependencies: PubspecParser.parse(pubspec.path)
+        }));
 
-          const batchResults = await processPackageBatch(dependencies, startIndex, batchSize);
-          packages.push(...batchResults);
+        totalDependencies = pubspecDependencies.reduce((sum, pd) => sum + pd.dependencies.length, 0);
+
+        // Process each pubspec
+        for (const { pubspec, dependencies } of pubspecDependencies) {
+          const batchSize = 4;
+          const totalBatches = Math.ceil(dependencies.length / batchSize);
+
+          for (let batchIndex = 0; batchIndex < totalBatches; batchIndex++) {
+            const startIndex = batchIndex * batchSize;
+            const endIndex = Math.min(startIndex + batchSize, dependencies.length);
+            const actualBatchSize = endIndex - startIndex;
+            
+            progress.report({
+              message: `${processedDependencies + actualBatchSize} of ${totalDependencies} packages checked`,
+              increment: (actualBatchSize / totalDependencies) * 100
+            });
+
+            const batchResults = await processPackageBatch(
+              dependencies, 
+              startIndex, 
+              batchSize,
+              pubspec.path,
+              pubspec.projectName
+            );
+            allPackages.push(...batchResults);
+            processedDependencies += actualBatchSize;
+          }
         }
 
-        treeProvider.setPackages(packages);
+        treeProvider.setPackages(allPackages);
         updateBadge();
         updateStatusBar();
       }
     );
   } catch (error) {
-    vscode.window.showErrorMessage(`Failed to parse pubspec.yaml: ${error}`);
+    vscode.window.showErrorMessage(`Failed to parse pubspec files: ${error}`);
     treeView.badge = undefined;
   }
 }
@@ -200,13 +251,10 @@ async function showChangelogAsDocument(packageInfo: PackageInfo) {
       packageInfo.currentVersion, 
       packageInfo.latestVersion,
       async (packageName: string, version: string) => {
-        // Handle update button click
-        const pubspecPath = await findPubspecPath();
-        if (pubspecPath) {
-          const success = await Updater.updatePackage(pubspecPath, packageName, version);
-          if (success) {
-            setTimeout(() => refreshPackages(), 1000);
-          }
+        // Handle update button click - use pubspecPath from packageInfo
+        const success = await Updater.updatePackage(packageInfo.pubspecPath, packageName, version);
+        if (success) {
+          setTimeout(() => refreshPackages(), 1000);
         }
       }
     );

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -1,5 +1,26 @@
 import * as vscode from 'vscode';
-import { PackageInfo } from './types';
+import { PackageInfo, ProjectGroup } from './types';
+
+export class ProjectTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly projectGroup: ProjectGroup,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState
+  ) {
+    super(projectGroup.projectName, collapsibleState);
+
+    this.tooltip = projectGroup.pubspecPath;
+    this.contextValue = 'project';
+    
+    // Set description to show outdated count
+    if (projectGroup.outdatedCount > 0) {
+      this.description = `${projectGroup.outdatedCount} outdated`;
+      this.iconPath = new vscode.ThemeIcon('folder', new vscode.ThemeColor('editorWarning.foreground'));
+    } else {
+      this.description = 'up to date';
+      this.iconPath = new vscode.ThemeIcon('folder', new vscode.ThemeColor('testing.iconPassed'));
+    }
+  }
+}
 
 export class PackageTreeItem extends vscode.TreeItem {
   constructor(
@@ -46,15 +67,49 @@ export class PackageTreeItem extends vscode.TreeItem {
   }
 }
 
-export class PackageTreeProvider implements vscode.TreeDataProvider<PackageTreeItem> {
-  private _onDidChangeTreeData = new vscode.EventEmitter<PackageTreeItem | undefined | null | void>();
+export class PackageTreeProvider implements vscode.TreeDataProvider<ProjectTreeItem | PackageTreeItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<ProjectTreeItem | PackageTreeItem | undefined | null | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   
   private packages: PackageInfo[] = [];
+  private projectGroups: ProjectGroup[] = [];
 
   setPackages(packages: PackageInfo[]) {
     this.packages = packages;
+    this.projectGroups = this.groupPackagesByProject(packages);
     this._onDidChangeTreeData.fire();
+  }
+
+  private groupPackagesByProject(packages: PackageInfo[]): ProjectGroup[] {
+    const groupMap = new Map<string, PackageInfo[]>();
+    
+    // Group packages by pubspec path
+    for (const pkg of packages) {
+      const existing = groupMap.get(pkg.pubspecPath) || [];
+      existing.push(pkg);
+      groupMap.set(pkg.pubspecPath, existing);
+    }
+
+    // Convert to ProjectGroup array
+    const groups: ProjectGroup[] = [];
+    for (const [pubspecPath, pkgs] of groupMap.entries()) {
+      const projectName = pkgs[0].projectName;
+      const outdatedCount = pkgs.filter(p => p.isOutdated).length;
+      
+      groups.push({
+        projectName,
+        pubspecPath,
+        packages: pkgs,
+        outdatedCount
+      });
+    }
+
+    // Sort groups: projects with outdated packages first, then alphabetically
+    return groups.sort((a, b) => {
+      if (a.outdatedCount > 0 && b.outdatedCount === 0) return -1;
+      if (a.outdatedCount === 0 && b.outdatedCount > 0) return 1;
+      return a.projectName.localeCompare(b.projectName);
+    });
   }
 
   getOutdatedCount(): number {
@@ -65,23 +120,33 @@ export class PackageTreeProvider implements vscode.TreeDataProvider<PackageTreeI
     this._onDidChangeTreeData.fire();
   }
 
-  getTreeItem(element: PackageTreeItem): vscode.TreeItem {
+  getTreeItem(element: ProjectTreeItem | PackageTreeItem): vscode.TreeItem {
     return element;
   }
 
-  getChildren(element?: PackageTreeItem): Thenable<PackageTreeItem[]> {
+  getChildren(element?: ProjectTreeItem | PackageTreeItem): Promise<(ProjectTreeItem | PackageTreeItem)[]> {
     if (!element) {
-      // Sort: outdated packages first, then up-to-date packages
-      const sorted = [...this.packages].sort((a, b) => {
+      // Root level: show project groups
+      return Promise.resolve(
+        this.projectGroups.map(group => 
+          new ProjectTreeItem(group, vscode.TreeItemCollapsibleState.Expanded)
+        )
+      );
+    }
+    
+    if (element instanceof ProjectTreeItem) {
+      // Project level: show packages sorted by outdated status
+      const sorted = [...element.projectGroup.packages].sort((a, b) => {
         if (a.isOutdated && !b.isOutdated) return -1;
         if (!a.isOutdated && b.isOutdated) return 1;
-        return a.name.localeCompare(b.name); // Alphabetical within each group
+        return a.name.localeCompare(b.name);
       });
       
       return Promise.resolve(
         sorted.map(pkg => new PackageTreeItem(pkg, vscode.TreeItemCollapsibleState.None))
       );
     }
+    
     return Promise.resolve([]);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,15 @@ export interface PackageInfo {
   isOutdated: boolean;
   updateType: UpdateType;
   changelog?: string;
+  pubspecPath: string;
+  projectName: string;
+}
+
+export interface ProjectGroup {
+  projectName: string;
+  pubspecPath: string;
+  packages: PackageInfo[];
+  outdatedCount: number;
 }
 
 export interface PubspecDependency {


### PR DESCRIPTION
This PR adds full support for Flutter workspaces and monorepos with multiple pubspec.yaml files.

**Key Changes**
- Auto-discovery: Recursively finds all pubspec.yaml files across the workspace (excludes .fvm directories)
- Hierarchical tree view: Projects organized in collapsible groups with per-project outdated counts
- Per-project updates: Each package update targets the correct project's pubspec.yaml
- Smart sorting: Projects with outdated packages shown first, packages within projects sorted by status
- Enhanced UI: Project folders show colored icons and badges based on update status

**Technical Details**
- Extended PackageInfo type with pubspecPath and projectName fields
- Created ProjectGroup interface for hierarchical organization
- Refactored refreshPackages() to process multiple pubspecs in parallel batches
- Updated tree provider to support two-level hierarchy (Projects → Packages)
- Modified all command handlers to use pubspec context from selected package

**Benefits**
- Works seamlessly with both single-project and multi-project workspaces
- Respects existing VS Code files.exclude and search.exclude settings
- Backward compatible with existing single-project workflows
- Improves package management for teams using Flutter monorepos