### PR TITLE
feat: exclude .fvm/ folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1 - Monorepo Support
+
+- Added support for `fvm`
+
 ## 2.0.0 - Monorepo Support
 
 - Monorepo support: auto-detects all pubspec.yaml files and groups packages by project

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutter-pubgrade",
   "displayName": "Pubgrade",
   "description": "Manage packages: check updates, view changelogs, update with one click",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publisher": "KamranBekirov",
   "icon": "resources/icon.png",
   "author": {

--- a/src/pubspecParser.ts
+++ b/src/pubspecParser.ts
@@ -4,7 +4,7 @@ import * as yaml from 'js-yaml';
 import * as vscode from 'vscode';
 import { PubspecDependency } from './types';
 
-const EXCLUDED_DIRS = ['build', '.dart_tool', '.symlinks', '.plugin_symlinks', 'ios', 'android', 'web', 'macos', 'linux', 'windows'];
+const EXCLUDED_DIRS = ['build', '.dart_tool', '.symlinks', '.plugin_symlinks', 'ios', 'android', 'web', 'macos', 'linux', 'windows', '.fvm'];
 
 export class PubspecParser {
   static parse(filePath: string): PubspecDependency[] {


### PR DESCRIPTION
Hey, thanks for your cool VS Code extension!

I just tried it out today and have encountered a big bug when having flutter installed with fvm and fvm setup for a project.


<img width="450" alt="image" src="https://github.com/user-attachments/assets/0cbd12d7-3c77-4eb3-934a-4af84ef24f99" />

Because of fvm's `.fvm/` folder having a local symlink to flutter and its inner dependencies, it will retrieve all pubspec.yaml files too and adding a lot more dependencies to my project that I have.

With my PR fix it looks correctly again:

<img width="450" alt="image" src="https://github.com/user-attachments/assets/ced1323c-e035-4910-b79e-5b54548f2dbb" />



